### PR TITLE
Update selenium-server, introduce setMaskedElValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ For instructions on how to run tests, please see the `magellan` documentation at
 Tests are structured as simple modules with a single exported object containing keyed functions. The functions are executed in the order in which they appear in the object source. Each function represents a step in the test, and its key in the test object should represent the name of the step. Each step function gets a `client` as an argument which represents a browser. For more information on writing tests, see the [Nightwatch.js documentation](http://nightwatchjs.org).
 
 ```javascript
-  module.exports = {
+  var MagellanTest = require("testarmada-magellan-nightwatch/lib/base-test-class");
+
+  module.exports = new MyTest({
     "Load homepage": function (client) {
       client
         .url("http://localhost/");
@@ -28,8 +30,10 @@ Tests are structured as simple modules with a single exported object containing 
         .getEl("#help-modal")
         .assert.elContainsText("#help-modal", "This is the help modal");
     }
-  }
+  });
 ```
+
+For more examples, see the boilerplate project at: https://github.com/TestArmada/boilerplate
 
 ## Command Vocabulary
 
@@ -152,3 +156,49 @@ Some Nightwatch commands and assertions are supported out of the box.
 
 `magellan-nightwatch` supports the development of custom commands to allow the re-use of common parts of tests. If you're using the same snippets of code to fill out a form that appears in many tests, or have a common way to sign into your application, etc, then custom commands are for you. Please see the [Nightwatch.js documentation](http://nightwatchjs.org) for more on commands.
 
+#### Migrating Nightwatch Configuration
+
+To migrate an existing vanilla `nightwatch.json` configuration to `magellan-nightwatch`, update the following 
+
+Add Magellan's custom commands to your `custom_commands_path`:
+
+```
+  "custom_commands_path": [
+    "./node_modules/testarmada-magellan-nightwatch/lib/commands",
+```
+
+Add Magellan's custom assertions to your `custom_assertions_path`:
+
+```
+  "custom_assertions_path": [
+    "./node_modules/testarmada-magellan-nightwatch/lib/assertions",
+```
+
+Ensure Selenium server/driver paths are correct:
+
+```
+  "selenium": {
+    "start_process": true,
+    "server_path": "./node_modules/testarmada-magellan-nightwatch/node_modules/selenium-server/lib/runner/selenium-server-standalone-2.46.0.jar",
+    "log_path": "reports",
+    "host": "127.0.0.1",
+    "port": 4444,
+    "cli_args": {
+      "webdriver.chrome.driver": "./node_modules/testarmada-magellan-nightwatch/node_modules/chromedriver/lib/chromedriver/chromedriver",
+      "webdriver.ie.driver": ""
+    }
+  },
+```
+
+**Note: pay special attention to the version number for the selenium server above, currently at version `2.46.0`***
+
+Set up `phantomjs` path:
+
+```
+  "phantomjs" : {
+    "desiredCapabilities" : {
+      "browserName" : "phantomjs",
+      "javascriptEnabled" : true,
+      "acceptSslCerts" : true,
+      "phantomjs.binary.path" : "./node_modules/testarmada-magellan-nightwatch/node_modules/phantomjs/bin/phantomjs"
+```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If you're familiar with Nightwatch or are looking to translate Nightwatch exampl
   <tr>
     <td>Nightwatch Command / Assertion</td>
     <td>`magellan-nightwatch` Equivalent</td>
+    <td>Description</td>
   </tr>
   <tr>
     <td>click("[data-automation-id="mybutton"])</td>
@@ -65,6 +66,11 @@ If you're familiar with Nightwatch or are looking to translate Nightwatch exampl
     <td>setElValue(selector, value)</td>
   </tr>
   <tr>
+    <td>(no nightwatch equivalent)</td>
+    <td>setMaskedElValue(selector, value, [fieldLength])</td>
+    <td>Set a value on a field that's using a mask (eg: MM/DD/YYYY or (555) 123-4567) with caret control</td>
+  </tr>
+  <tr>
     <td>waitForElementNotPresent(selector)</td>
     <td>waitForElNotPresent(selector)</td>
   </tr>
@@ -77,15 +83,15 @@ If you're familiar with Nightwatch or are looking to translate Nightwatch exampl
     <td>assert.elContainsText(selector, regex or text)</td>
   </tr>
   <tr>
-    <td>_(no nightwatch equivalent)_</td>
+    <td>(no nightwatch equivalent)</td>
     <td>assert.elNotContainsText(selector, text)</td>
   </tr>
   <tr>
-    <td>_(no nightwatch equivalent)_</td>
+    <td>(no nightwatch equivalent)</td>
     <td>assert.selectorHasLength(selector, expectedLength)</td>
   </tr>
   <tr>
-  <td>_(no nightwatch equivalent)_</td>
+  <td>(no nightwatch equivalent)</td>
     <td>assert.elLengthGreaterThan(selector, selectUsing, lengthToCompare)</td>
   </tr>
 </table>

--- a/lib/commands/setMaskedElValue.js
+++ b/lib/commands/setMaskedElValue.js
@@ -1,0 +1,122 @@
+//
+// A more reliable version setValue() that does the same thing as setElValue() except
+// is made to work well with masked inputs like mm/dd/yyyy and (xxx) yyy-zzzz , etc.
+// These types of inputs often have actual text already in the input and exert control
+// over caret position as the user types. For this reason, we try to enter text with
+// care and attempt to place the caret in a beginning position.
+//
+
+var util = require("util");
+var CheckVisibleAndClick = require("./lib/checkVisibleAndClick");
+var acquirejQuery = require("../acquire-jquery");
+
+// Wait until we've seen a selector as :visible SEEN_MAX times, with a
+// wait for WAIT_INTERVAL milliseconds between each visibility test.
+var settings = require("../settings");
+var MAX_TIMEOUT = settings.COMMAND_MAX_TIMEOUT;
+var WAIT_INTERVAL = 100;
+var SEEN_MAX = 3;
+var KEYBOARD_DELAY = 250;
+var DEFAULT_FIELDSIZE = 50;
+
+function SetMaskedElValue () {
+  CheckVisibleAndClick.call(this);
+  this.checkConditions = this.checkConditions.bind(this);
+  this.pass = this.pass.bind(this);
+  this.fail = this.fail.bind(this);
+}
+
+util.inherits(SetMaskedElValue, CheckVisibleAndClick);
+
+SetMaskedElValue.prototype.command = function (selector, valueToSet, /* optional */ fieldSize, cb) {
+  this.valueToSet = valueToSet;
+  this.selector = selector;
+
+  if (typeof fieldSize === 'number') {
+    this.fieldSize = fieldSize;
+    this.cb = cb;
+  } else if (typeof fieldSize === 'function') {
+    this.fieldSize = DEFAULT_FIELDSIZE;
+    this.cb = fieldSize;
+  }
+
+  this.successMessage = "Selector <" + this.selector+ "> (masked) set value to [" + this.valueToSet + "] after %d milliseconds";
+  this.failureMessage = "Selector <" + this.selector+ "> (masked) could not set value to [" + this.valueToSet + "] after %d milliseconds";
+
+  this.startTime = (new Date()).getTime();
+
+  // Track how many times we've seen selector as :visible
+  this.seenCount = 0;
+
+  this.checkConditions();
+
+  return this;
+};
+
+// set a value on an element with the assumption that it is ready/settled
+SetMaskedElValue.prototype._setValue = function () {
+  // NOTE: Assumes valueToSet is a string.
+  var self = this;
+
+  var client = self.client.api;
+
+  // Send 50 <- keys first (NOTE: this assumes LTR text flow!)
+  var backarrows = [];
+  for (var i = 0; i < this.fieldSize; i++) {
+    backarrows.push("\uE012");
+  }
+
+  var keys = backarrows.concat(self.valueToSet.split(""));
+
+  var nextKey = function () {
+    if (keys.length === 0) {
+      client.pause(KEYBOARD_DELAY, function () {
+        self.pass();
+      });
+    } else {
+      var key = keys.shift();
+      client
+        .pause(KEYBOARD_DELAY)
+        .keys(key, function () {
+          nextKey();
+        });
+    }
+  };
+
+  client
+    .click(self.selector, function () {
+      nextKey();
+    });
+};
+
+SetMaskedElValue.prototype.checkConditions = function () {
+  var self = this;
+
+  // wait until an element is ready/settled
+  this.execute(this.checkVisibleAndClick, [self.selector, false], function (result) {
+    if (result.isVisible && result.selectorLength === 1) {
+      self.seenCount++;
+    }
+
+    // If we've seen the selector enough times or waited too long, continue w/ checkElement
+    var elapsed = (new Date()).getTime() - self.startTime;
+    if (self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
+      if (self.seenCount >= SEEN_MAX) {
+        // We're convinced the element is ready. Now set its value
+        self._setValue();
+      } else {
+        // We're about to fail. If we DO see the selector but selectorLength was > 1,
+        // issue a warning that the test had an ambiguous target to click on
+        if (result.selectorLength > 1) {
+          console.log("WARNING: setMaskedElValue saw selector " + self.selector + " but result length was " + result.selectorLength + ", with " + result.selectorVisibleLength + " of those :visible");
+          console.log("Selector did not disambiguate after " + elapsed + " milliseconds, refine your selector or check DOM for problems.");
+        }
+        self.fail();
+      }
+    } else {
+      setTimeout(self.checkConditions, WAIT_INTERVAL);
+    }
+  });
+};
+
+module.exports = SetMaskedElValue;

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "qs": "2.2.4",
     "request": "2.40.0",
     "sanitize-filename": "1.3.0",
-    "selenium-server": "2.43.1",
+    "selenium-server": "2.46.0",
     "send": "0.10.1",
     "yargs": "1.3.2"
   }


### PR DESCRIPTION
This PR:
  - updates selenium-server to `2.46.0`
  - adds `setMaskedElValue` command
  - adds a note about how to migrate to the correct version of `selenium-server` and migrate `nightwatch.json` in general
  - corrects test example to actually use `magellan-nightwatch` base class (oops!)