### PR TITLE
Fix default fieldSize in setMaskedElValue()

### DIFF
--- a/lib/commands/setMaskedElValue.js
+++ b/lib/commands/setMaskedElValue.js
@@ -35,7 +35,7 @@ SetMaskedElValue.prototype.command = function (selector, valueToSet, /* optional
   if (typeof fieldSize === 'number') {
     this.fieldSize = fieldSize;
     this.cb = cb;
-  } else if (typeof fieldSize === 'function') {
+  } else {
     this.fieldSize = DEFAULT_FIELDSIZE;
     this.cb = fieldSize;
   }


### PR DESCRIPTION
This PR fixes a bug in the default assignment of `fieldSize`.