### PR TITLE
Send jQuery through the wire in chunks to overcome Selendroid's 65K string limit for arguments

### DIFF
--- a/lib/assertions/elContainsText.js
+++ b/lib/assertions/elContainsText.js
@@ -48,8 +48,8 @@ exports.assertion = function(selector, expectedContainedText) {
           var result = checkString(elText, text);
 
           if (!result) {
-            // Collapse whitespaces and newlines in order to work around wonky
-            // spacing caused by the DOM
+            /* Collapse whitespaces and newlines in order to work around wonky
+               spacing caused by the DOM */
             elText = elText.replace(/[\s|\n]+/g, ' ');
             result = checkString(elText, text);
           }

--- a/lib/assertions/elLengthGreaterThan.js
+++ b/lib/assertions/elLengthGreaterThan.js
@@ -33,7 +33,8 @@ exports.assertion = function(selector, selectUsing, lengthToCompare) {
 
       if (jQueryRef) {
         var use = selectUsing.toLowerCase();
-        var lengthRecieved; // this is just created to show the correct length when troubleshooting for assertion failure  
+        /* this is just created to show the correct length when troubleshooting for assertion failure */
+        var lengthRecieved;
         if (use == 'text') {
           lengthRecieved = jQueryRef(sel).text().trim().length;
         } else if (use == 'value') {

--- a/lib/assertions/elNotContainsText.js
+++ b/lib/assertions/elNotContainsText.js
@@ -36,8 +36,8 @@ exports.assertion = function(selector, notExpectedContainedText) {
           var result = !regex.exec(elText);
 
           if (!result) {
-            // Collapse whitespaces and newlines in order to work around wonky
-            // spacing caused by the DOM
+            /* Collapse whitespaces and newlines in order to work around wonky
+               spacing caused by the DOM */
             elText = elText.replace(/[\s|\n]+/g, ' ');
             result = !text.exec(elText);
           }

--- a/lib/commands/lib/checkVisibleAndClick.js
+++ b/lib/commands/lib/checkVisibleAndClick.js
@@ -7,7 +7,30 @@ var jquerySource = fs.readFileSync(__dirname + "/../../../injectable_scripts/jqu
 var acquirejQuery = require("../../acquire-jquery");
 var settings = require("../../settings");
 
+var chunkify = function (bigstr) {
+  var chunkSize = 48000;
+  var chunks = [];
+  var lastAcc;
+
+  bigstr.split("").reduce(function (acc, ch) {
+    if (acc.length === chunkSize) {
+      chunks.push(acc);
+      acc = "";
+    }
+    acc += ch;
+    lastAcc = acc;
+    return acc;
+  }, "");
+
+  if (lastAcc && lastAcc.length > 0) {
+    chunks.push(lastAcc);
+  }
+
+  return chunks;
+};
+
 function CheckVisibleAndClick() {
+  this.remainingChunks = chunkify(jquerySource);
   EventEmitter.call(this);
 }
 
@@ -32,8 +55,12 @@ CheckVisibleAndClick.prototype.execute = function (fn, args, callback) {
   // time we run execute(), but does cost us one "beat" when we are
   // using an external site that needs injection for shimming.
   if (this.jqueryInjectionRequested === true) {
-    args.push(jquerySource);
-    this.jqueryInjectionRequested = false;
+    if (this.remainingChunks.length > 0) {
+      args.push(this.remainingChunks.shift());
+      this.jqueryInjectionRequested = false;
+    } else {
+      args.push(undefined);
+    }
   } else {
     args.push(undefined);
   }
@@ -107,7 +134,7 @@ CheckVisibleAndClick.prototype.fail = function (expected, actual) {
 // resulting elements were visible. If shouldClick is set to true,
 // then optionally click if the selector result length is 1 (i.e.
 // if the selector result is unambigous -- don't click multiple things)
-CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick, jquerySource, acquirejQuery) {
+CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick, jquerySourceChunk, acquirejQuery) {
   // In context of browser, ask if the selector is :visible according to jQuery
   var jQueryRef;
 
@@ -175,13 +202,37 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
 
     // Check if we have the source code available. If not, we will need
     // to request it with jqueryInjectionRequested (see below).
-    if (typeof jquerySource === "string" && jquerySource.length > 1000) {
-      // jQuery hasn't been loaded. We make sure that we haven't already started
-      // loading the script before we try to insert a script tag
+    if (typeof jquerySourceChunk === "string" && jquerySourceChunk.length > 1) {
+
+      // Accumulation phase.
+      if (!window.____injectedJQuerySource____) {
+        window.____injectedJQuerySource____ = "";
+      }
+
+      window.____injectedJQuerySource____ += jquerySourceChunk;
+
+      return {
+        // Ask for more
+        jqueryInjectionRequested: true,
+        isVisibleStrict: null,
+        isVisible: false,
+        selectorVisibleLength: 0,
+        selectorLength: 0
+      };
+    } else if (window.____injectedJQuerySource____) {
+
+      // Evaluation Phase
       try {
-        eval(jquerySource);
+        eval(window.____injectedJQuerySource____);
         window.____injectedJQuery____ = jQuery;
         jQuery.noConflict();
+
+        return {
+          isVisibleStrict: null,
+          isVisible: false,
+          selectorVisibleLength: 0,
+          selectorLength: 0
+        };
       } catch (e) {
         return {
           isVisibleStrict: null,
@@ -190,13 +241,6 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
           selectorLength: 0
         };
       }
-
-      return {
-        isVisibleStrict: null,
-        isVisible: false,
-        selectorVisibleLength: 0,
-        selectorLength: 0
-      };
     } else {
       // Request injection if we don't have the jQuery source but we need it
       return {

--- a/lib/commands/lib/checkVisibleAndClick.js
+++ b/lib/commands/lib/checkVisibleAndClick.js
@@ -83,7 +83,7 @@ CheckVisibleAndClick.prototype.execute = function (fn, args, callback) {
         self.jqueryInjectionRequested = true;
       }
 
-      // If we asked if it's okay to click and got back an all-clear, let's actually do it.
+      // If we asked if it is okay to click and got back an all-clear, then actually click.
       if (result.value.doSeleniumClick) {
         self.doSeleniumClick(function () {
           callback.call(self, result.value);
@@ -135,11 +135,11 @@ CheckVisibleAndClick.prototype.fail = function (expected, actual) {
 // then optionally click if the selector result length is 1 (i.e.
 // if the selector result is unambigous -- don't click multiple things)
 CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick, jquerySourceChunk, acquirejQuery) {
-  // In context of browser, ask if the selector is :visible according to jQuery
+  /* In context of browser, ask if the selector is :visible according to jQuery */
   var jQueryRef;
 
-  // The non-jQuery click solution has not been tested outside of Chrome and Phantom and
-  // likely does not work in IE. This needs to be tested.
+  /* The non-jQuery click solution has not been tested outside of Chrome and Phantom and
+     likely does not work in IE. This needs to be tested. */
   var useJQueryClick = true;
 
   var jQueryRef = (new Function(acquirejQuery))();
@@ -157,17 +157,17 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
 
       var doSeleniumClick = false;
 
-      // If selector:visible and we've been told to click then signal back that it's okay to click(),
-      // unless we see a selector that is ambiguous (i.e number of results
-      // is greater than 1).
+      /* If selector:visible and we have been told to click then signal back that it is okay to click(),
+         unless we see a selector that is ambiguous (i.e number of results
+         is greater than 1). */
       if (isVisible && $el.length === 1) {
-        // We avoid using data-automation-id so that we don't accidentally blow away existing attributes.
+        /* We avoid using data-automation-id so that we do not accidentally blow away existing attributes. */
         var seleniumClickSelectorValue = "magellan_click_" + Math.round(Math.random() * 999999999).toString(16);
         var seleniumClickSelector = "[data-magellan-temp-automation-id='" + seleniumClickSelectorValue + "']";
         $el[0].setAttribute("data-magellan-temp-automation-id", seleniumClickSelectorValue);
 
         if (shouldClick) {
-          // Unfortunately in Thorax applications we have trouble clicking
+          /* Unfortunately in Thorax applications we have trouble clicking */
           if ($el.is("input[type='radio']") || $el.is("input[type='checkbox']")) {
             $el.click();
           } else {
@@ -177,10 +177,10 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
       }
 
       return {
-        // Note: this is the only case in which we return a boolean for isVisibleStrict
-        // In all other cases, we return null because we effectively "don't know yet".
-        // This helps cases like waitForElNotPresent that can't have "false" returned
-        // unless we've successfully checked if it's not visible.
+        /* Note: this is the only case in which we return a boolean for isVisibleStrict
+           In all other cases, we return null because we effectively "do not know yet".
+           This helps cases like waitForElNotPresent that cannot have "false" returned
+           unless we have successfully checked if it is not visible. */
         seleniumClickSelector: seleniumClickSelector,
         doSeleniumClick: doSeleniumClick,
         isVisibleStrict: isVisible,
@@ -189,8 +189,8 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
         selectorLength: $el.length
       };
     } catch (e) {
-      // if for whatever reason we fail here, we do not want Selenium returning
-      // a null result value back to Magellan. For now, we eat this exception.
+      /* if for whatever reason we fail here, we do not want Selenium returning
+         a null result value back to Magellan. For now, we eat this exception. */
       return {
         isVisibleStrict: null,
         isVisible: false,
@@ -200,11 +200,11 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
     }
   } else if (!jQueryRef) {
 
-    // Check if we have the source code available. If not, we will need
-    // to request it with jqueryInjectionRequested (see below).
+    /* Check if we have the source code available. If not, we will need
+       to request it with jqueryInjectionRequested (see below). */
     if (typeof jquerySourceChunk === "string" && jquerySourceChunk.length > 1) {
 
-      // Accumulation phase.
+      /* Accumulation phase. */
       if (!window.____injectedJQuerySource____) {
         window.____injectedJQuerySource____ = "";
       }
@@ -212,7 +212,7 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
       window.____injectedJQuerySource____ += jquerySourceChunk;
 
       return {
-        // Ask for more
+        /* Ask for more */
         jqueryInjectionRequested: true,
         isVisibleStrict: null,
         isVisible: false,
@@ -221,7 +221,7 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
       };
     } else if (window.____injectedJQuerySource____) {
 
-      // Evaluation Phase
+      /* Evaluation Phase */
       try {
         eval(window.____injectedJQuerySource____);
         window.____injectedJQuery____ = jQuery;
@@ -242,7 +242,7 @@ CheckVisibleAndClick.prototype.checkVisibleAndClick = function (sel, shouldClick
         };
       }
     } else {
-      // Request injection if we don't have the jQuery source but we need it
+      /* Request injection if we do not have the jQuery source but we need it */
       return {
         jqueryInjectionRequested: true,
         isVisibleStrict: null,

--- a/lib/commands/setElValue.js
+++ b/lib/commands/setElValue.js
@@ -49,7 +49,7 @@ SetValueToSettledElement.prototype._enterValueDirectly = function () {
   var self = this;
 
   this.execute(function (sel, valueToSet, acquirejQuery) {
-    // Note: we would have already loaded, injected, or found a loaded jQuery by this point
+    /* Note: we would have already loaded, injected, or found a loaded jQuery by this point */
     var jQueryRef = (new Function(acquirejQuery))();
 
     if (jQueryRef) {
@@ -86,7 +86,7 @@ SetValueToSettledElement.prototype._shouldUseKeyboardWorkaround = function (cb) 
       if (jQueryRef) {
         isMaskedInputField = (typeof jQueryRef(selector).data("rawMaskFn") === "function");
       } else {
-        // this is unknowlable if we don't have jQuery
+        /* this is unknowlable if we do not have jQuery loaded */
         isMaskedInputField = false;
       }
       return isMaskedInputField;

--- a/lib/magellan-error-listener.js
+++ b/lib/magellan-error-listener.js
@@ -1,11 +1,11 @@
 module.exports = function () {
-  // Magellan harvests as often as possible to prevent loss to URL changes 
-  // (i.e. before interaction command, before 
-  // change URL command).
+  /* Magellan harvests as often as possible to prevent loss to URL changes 
+     (i.e. before interaction command, before 
+     change URL command). */
   if (window && window.addEventListener) {
     var Magellan = window.__Magellan__;
 
-    // Initialize Magellan's error listener if it's not present
+    /* Initialize the Magellan error listener if it is not present */
     if (!Magellan) {
       window.__Magellan__ = {
         startTime: (new Date()).getTime(),
@@ -14,7 +14,7 @@ module.exports = function () {
       Magellan = window.__Magellan__;
 
       window.addEventListener("error", function (err) {
-        // Normalize errors that don't seem to be in the right format
+        /* Normalize errors that dont seem to be in the right format */
         var normalized = false;
 
         if (!(err && err.message && typeof err.message === "string")) {
@@ -25,7 +25,7 @@ module.exports = function () {
             err = new Error(err);
             normalized = true;
           } else {
-            // something else entirely
+            /* something else entirely */
             err = new Error(String(err));
             normalized = true;
           }
@@ -44,7 +44,7 @@ module.exports = function () {
       });
     }
 
-    // harvest and clear
+    /* harvest and clear */
     var errors = Magellan.errors;
     Magellan.errors = [];
     return errors;


### PR DESCRIPTION
Fixes https://github.com/TestArmada/magellan-nightwatch/issues/16

(Potentially -- there may still be a requirement to strip the code of comments as it crosses the wire).