### PR TITLE
Allow MAX_TIMEOUT to become a config setting

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -72,6 +72,14 @@ if (argv.screenshot_path) {
   screenshotPath = path.resolve("./temp");
 }
 
+// Parameter for COMMAND_MAX_TIMEOUT
+// This allows a config file to set it's own timeout value, as long as it's under the default 60000
+
+var timeoutSetting = 60000;
+if (config.nightwatchConfig.test_settings.default.max_timeout && config.nightwatchConfig.test_settings.default.max_timeout < timeoutSetting) {
+  timeoutSetting = config.nightwatchConfig.test_settings.default.max_timeout;
+}
+
 module.exports = {
   screenshotPath: screenshotPath,
 
@@ -80,7 +88,7 @@ module.exports = {
   // True if we've launched Magellan as part of a cluster (i.e. from a magellan-director or similar event consumer)
   isWorker: !!argv.worker,
 
-  COMMAND_MAX_TIMEOUT: 60000,
+  COMMAND_MAX_TIMEOUT: timeoutSetting,
 
   verbose: argv.verbose,
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -75,9 +75,9 @@ if (argv.screenshot_path) {
 // Parameter for COMMAND_MAX_TIMEOUT
 // This allows a config file to set it's own timeout value, as long as it's under the default 60000
 
-var timeoutSetting = 60000;
-if (config.nightwatchConfig.test_settings.default.max_timeout && config.nightwatchConfig.test_settings.default.max_timeout < timeoutSetting) {
-  timeoutSetting = config.nightwatchConfig.test_settings.default.max_timeout;
+var DEFAULT_MAX_TIMEOUT = 60000;
+if (config.nightwatchConfig.test_settings.default.max_timeout && config.nightwatchConfig.test_settings.default.max_timeout < DEFAULT_MAX_TIMEOUT) {
+  DEFAULT_MAX_TIMEOUT = config.nightwatchConfig.test_settings.default.max_timeout;
 }
 
 module.exports = {
@@ -88,7 +88,7 @@ module.exports = {
   // True if we've launched Magellan as part of a cluster (i.e. from a magellan-director or similar event consumer)
   isWorker: !!argv.worker,
 
-  COMMAND_MAX_TIMEOUT: timeoutSetting,
+  COMMAND_MAX_TIMEOUT: DEFAULT_MAX_TIMEOUT,
 
   verbose: argv.verbose,
 


### PR DESCRIPTION
@geekdave 
@Maciek416 
@chaseadamsio 

Hello all!.  I searched docs and code for something like this, but couldn't find anything, so thought I'd make the adjustment.

- Allows for an addition in the config file for `max_timeout` value (which lowers the time a test takes 'waiting' for elements)
- does not effect anyones existing configs
- does not allow for a value higher than 60secs

Example config:
```
  "test_settings": {
    "default": {
      "launch_url": "http://localhost",
      "selenium_port" : 4444,
      "selenium_host" : "localhost",
      "silent": true,
      "sync_test_names": true,
      "max_timeout": 5000,
```