### PR TITLE
Removing contrain on max_timeout value

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -73,12 +73,11 @@ if (argv.screenshot_path) {
 }
 
 // Parameter for COMMAND_MAX_TIMEOUT
-// This allows a config file to set it's own timeout value, as long as it's under the default 60000
+// This allows a config file to set it's own timeout value, will default to 60000
 
 var DEFAULT_MAX_TIMEOUT = 60000;
-if (config.nightwatchConfig.test_settings.default.max_timeout && config.nightwatchConfig.test_settings.default.max_timeout < DEFAULT_MAX_TIMEOUT) {
-  DEFAULT_MAX_TIMEOUT = config.nightwatchConfig.test_settings.default.max_timeout;
-}
+var timeoutValue = config.nightwatchConfig.test_settings.default.max_timeout || DEFAULT_MAX_TIMEOUT;
+
 
 module.exports = {
   screenshotPath: screenshotPath,
@@ -88,7 +87,7 @@ module.exports = {
   // True if we've launched Magellan as part of a cluster (i.e. from a magellan-director or similar event consumer)
   isWorker: !!argv.worker,
 
-  COMMAND_MAX_TIMEOUT: DEFAULT_MAX_TIMEOUT,
+  COMMAND_MAX_TIMEOUT: timeoutValue,
 
   verbose: argv.verbose,
 


### PR DESCRIPTION
@geekdave 

Default value will kick in if no value is set in the config.  No limitation on the timeout set.