### PR TITLE
add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ screenshots/*.png
 node_modules/*
 !node_modules/lib
 sauce_connect_log.txt
+temp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: node_js
+
+script:
+
+
+env:
+  - TEST_SUITE=chrome_latest_Windows_2012_R2_Desktop,firefox_latest_Windows_2012_R2_Desktop,IE_11_Windows_2012_R2_Desktop
+  - TEST_SUITE=safari_7_OS_X_10_9_Desktop,IE_8_Windows_2008_Desktop,IE_9_Windows_2008_Desktop,IE_10_Windows_2012_Desktop
+
+node_js:
+  - 0.10
+  - 0.12
+
+# Use container-based Travis infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+before_install:
+  # ensure latest npm installed.
+  - npm install -g npm
+  - npm --version
+  - export MAGELLAN_BUILD_NAME=${TRAVIS_JOB_ID}_${TRAVIS_JOB_NUMBER}
+  - export MAGELLAN_BUILD_ID=`date +%s`
+  - export SAUCE_TUNNEL_ID=${TRAVIS_JOB_ID}_${TRAVIS_JOB_NUMBER}
+
+

--- a/conf/nightwatch.json
+++ b/conf/nightwatch.json
@@ -1,0 +1,82 @@
+{
+  "src_folders": ["./tests"],
+  "output_folder": "reports",
+  "custom_commands_path": [
+    "./lib/commands"
+  ],
+  "custom_assertions_path": [
+    "./lib/assertions"
+  ],
+
+  "selenium": {
+    "start_process": true,
+    "server_path": "./node_modules/selenium-server/lib/runner/selenium-server-standalone-2.46.0.jar",
+    "log_path": "reports",
+    "host": "127.0.0.1",
+    "port": 4444,
+    "cli_args": {
+      "webdriver.chrome.driver": "./node_modules/chromedriver/lib/chromedriver/chromedriver",
+      "webdriver.ie.driver": ""
+    }
+  },
+
+  "test_settings": {
+    "default": {
+      "launch_url": "http://localhost",
+      "selenium_port" : 4444,
+      "selenium_host" : "localhost",
+      "silent": true,
+      "sync_test_names": true,
+      "screenshots": {
+        "enabled": false,
+        "path": ""
+      },
+      "desiredCapabilities": {
+        "browserName": "chrome"
+      }
+    },
+
+    "phantomjs" : {
+      "desiredCapabilities" : {
+        "browserName" : "phantomjs",
+        "javascriptEnabled" : true,
+        "acceptSslCerts" : true,
+        "phantomjs.binary.path" : "./node_modules/phantomjs/bin/phantomjs"
+      }
+    },
+
+    "safari": {
+      "desiredCapabilities": {
+        "browserName": "safari"
+      }
+    },
+
+    "firefox": {
+      "desiredCapabilities": {
+        "browserName": "firefox"
+      }
+    },
+
+    "chrome": {
+      "desiredCapabilities": {
+        "browserName": "chrome"
+      }
+    },
+
+    "sauce": {
+      "selenium_host": "ondemand.saucelabs.com",
+      "selenium_port": 80,
+      "username": "",
+      "access_key": "",
+      "desiredCapabilities": {
+        "browserName": "",
+        "platform": "",
+        "version": "",
+        "tunnel-identifier": ""
+      },
+      "selenium" : {
+        "start_process" : false
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Nightwatch.js adapter for Magellan",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "magellan",
+    "test:sauce": "magellan --create_tunnels --external_build_id=$TRAVIS_BUILD_ID --sauce --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --max_workers=${MAGELLAN_MAX_WORKERS} --browsers=$TIER_1_BROWSERS,$TIER_2_BROWSERS",
+    "magellan:setup": "exit 0",
+    "magellan:teardown": "exit 0"
   },
   "repository": {
     "type": "git",
@@ -84,5 +87,9 @@
     "selenium-server": "2.46.0",
     "send": "0.10.1",
     "yargs": "1.3.2"
+  },
+  "devDependencies": {
+    "nightwatch": "^0.7.9",
+    "testarmada-magellan": "3.0.3"
   }
 }

--- a/tests/github.js
+++ b/tests/github.js
@@ -1,0 +1,17 @@
+var Test = require("../lib/base-test-class");
+
+module.exports = new Test({
+
+  "Load TestArmada GitHub page": function (client) {
+    client
+      .url("https://github.com/TestArmada")
+      .assert.elContainsText(".org-name", "TestArmada")
+  },
+
+  "Navigate to magellan-nightwatch repo": function (client) {
+    client
+      .clickEl("[href='/TestArmada/magellan-nightwatch']")
+      .assert.elContainsText(".repository-meta-content", "Nightwatch.js adapter for Magellan")
+  }
+
+});

--- a/tests/walmart-book.js
+++ b/tests/walmart-book.js
@@ -1,0 +1,26 @@
+var Test = require("../lib/base-test-class");
+var url = "http://www.walmart.com/search/?query=sam%20walton%20made%20in%20america";
+module.exports = new Test({
+
+  "Search for Sam Walton Book": function (client) {
+    client
+      .resizeWindow(1280, 1024)
+      .url(url)
+  },
+
+  "Check product description": function (client) {
+    client
+      .assert.elContainsText("[data-item-id='403453'] .tile-heading", "My Story")
+      .assert.elContainsText("[data-item-id='403453'] .media-details", "Paperback")
+      .pause(5000)
+      .getLog('browser', function(logEntriesArray) {
+        console.log('Log length: ' + logEntriesArray.length);
+        logEntriesArray.forEach(function(log) {
+          console.log('[' + log.level + '] ' + log.timestamp + ' : ' + log.message);
+      });
+    });
+
+  }
+
+
+});


### PR DESCRIPTION
add some tests from the boilerplate repo, and the magellan runner as a dev dependency so that we have something to run with.  yes, it's a bit klein-bottley but it works!

runs a simple github and walmart test using phantomJS.  sauce builds are up next (but we have to find a way to host admiral without costing lots of $$$)