### PR TITLE
Fix recovery of saucelabs report links

### DIFF
--- a/lib/util/sauce.js
+++ b/lib/util/sauce.js
@@ -15,10 +15,9 @@ module.exports = {
    *                    False if the current tests are running on a local Selenium server
    */
   isSauceTest: function (client) {
-    // check for the presence of a sauce labs tunnel
-    return client.options &&
-      client.options.desiredCapabilities &&
-      client.options.desiredCapabilities["tunnel-identifier"]
+    // check for the presence of a sauce labs username / access key
+    var opt = client.options;
+    return opt && opt.desiredCapabilities && (opt.accessKey || opt.username);
   },
 
   getTestUrl: function () {


### PR DESCRIPTION
This PR fixes the recovering saucelabs report links. In the current version of the codebase, if we're not using a sauce connect tunnel, we don't get a link.

/cc @geekdave 