### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,17 +158,17 @@ You can use [regexper](http://regexper.com/#Price%20%5Cd%2B%5C.%5Cd%5Cd) to help
 
 ### As-is Supported Nightwatch Vocabulary
 
-After the merge of [PR #12](https://github.com/TestArmada/magellan-nightwatch/pull/12), all Nightwatch commands and assertions are supported out of the box.
+All Nightwatch commands and assertions are supported out of the box.
 
 #### Supported Nightwatch Commands
 
-Please refer to http://nightwatchjs.org/api#commands for a list of supported Nightwatch commands
+* Please refer to http://nightwatchjs.org/api#commands for a list of supported Nightwatch commands
 
 #### Supported Nightwatch Assertions
 
-Please refer to http://nightwatchjs.org/api#assertions for a list of supported Nightwatch assertions
+* Please refer to http://nightwatchjs.org/api#assertions for a list of supported Nightwatch assertions
 
-(From node):
+#### Supported Node Assertions
 
 * `fail`
 * `equal`

--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ All Nightwatch commands and assertions are supported out of the box.
 
 #### Supported Nightwatch Commands
 
-* Please refer to http://nightwatchjs.org/api#commands for a list of supported Nightwatch commands
+* Please refer to [Nightwatch Commands API](http://nightwatchjs.org/api#commands) for a list of supported Nightwatch commands
 
 #### Supported Nightwatch Assertions
 
-* Please refer to http://nightwatchjs.org/api#assertions for a list of supported Nightwatch assertions
+* Please refer to [Nightwatch Assertions API](http://nightwatchjs.org/api#assertions) for a list of supported Nightwatch assertions
 
 #### Supported Node Assertions
 
@@ -179,7 +179,7 @@ All Nightwatch commands and assertions are supported out of the box.
 * `notStrictEqual`
 * `throws`
 * `doesNotThrow`
-* `ifErro`
+* `ifError`
 
 #### Custom Commands
 
@@ -219,7 +219,7 @@ Ensure Selenium server/driver paths are correct:
   },
 ```
 
-**Note: pay special attention to the version number for the selenium server above, currently at version `2.46.0`***
+**Note: pay special attention to the version number for the selenium server above, currently at version `2.49.0`***
 
 Set up `phantomjs` path:
 

--- a/README.md
+++ b/README.md
@@ -158,27 +158,15 @@ You can use [regexper](http://regexper.com/#Price%20%5Cd%2B%5C.%5Cd%5Cd) to help
 
 ### As-is Supported Nightwatch Vocabulary
 
-Some Nightwatch commands and assertions are supported out of the box.
+After the merge of [PR #12](https://github.com/TestArmada/magellan-nightwatch/pull/12), all Nightwatch commands and assertions are supported out of the box.
 
 #### Supported Nightwatch Commands
 
-* `clearValue()`
-* `pause()`
-* `attributeEquals()`
-* `saveScreenshot()`
-* `setCookie()`
-* `url()`
-* `getText()`
-* `getValue()`
+Please refer to http://nightwatchjs.org/api#commands for a list of supported Nightwatch commands
 
 #### Supported Nightwatch Assertions
 
-* `cssClassPresent()`
-* `cssProperty()`
-* `elementNotPresent()`
-* `elementPresent()`
-* `urlContains()`
-* `visible()`
+Please refer to http://nightwatchjs.org/api#assertions for a list of supported Nightwatch assertions
 
 (From node):
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you're familiar with Nightwatch or are looking to translate Nightwatch exampl
   <tr>
     <td>click("[data-automation-id="mybutton"])</td>
     <td>clickAutomationEl("mybutton")</td>
+    <td>Need "data-automation-id" attribute in the clickable HTML element</td>
   </tr>
   <tr>
     <td>click(selector)</td>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you're familiar with Nightwatch or are looking to translate Nightwatch exampl
   <tr>
     <td>click("[data-automation-id="mybutton"])</td>
     <td>clickAutomationEl("mybutton")</td>
-    <td>Need "data-automation-id" attribute in the clickable HTML element</td>
+    <td>Needs "data-automation-id" attribute in the clickable HTML element's DOM for this command to work</td>
   </tr>
   <tr>
     <td>click(selector)</td>


### PR DESCRIPTION
This PR:

* Updates the `README` of magellan-nightwatch to reflect the new changes after #12 was merged. Currently the `README` states that only a subset of the Nightwatch commands & assertions are supported (due to the former whitelist), but this is no longer the case

* Fixes a couple of typos

* Updates the command table to emphasize `data-automation-id` attribute is needed in order to use `clickAutomationEl()` command