### PR TITLE
Send selenium session info to magellan (magellan 8 support)

### DIFF
--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -35,6 +35,8 @@ var emitStartedTest = function(client) {
   if (settings.isWorker === true) {
     var testName = client.currentTest.module;
 
+    // Note: This is for Magellan versions earlier than 8 and will be ignored by
+    // magellan versions 8 and above.
     process.send({
       type: "worker-status",
       status: "started",
@@ -110,7 +112,7 @@ MagellanBaseTest.prototype = {
     // flag, so that we only perform this update once per-file.)
     if (!this.notifiedListenersOfStart) {
       emitStartedTest(client);
-      
+
       if (settings.isWorker === true) {
         this.handleExternalMessage = function (message) {
           if (message && message.signal === "bail") {

--- a/lib/selenium-session-acquisition-wrapper.js
+++ b/lib/selenium-session-acquisition-wrapper.js
@@ -4,6 +4,13 @@ var getSessionId = function (client) {
   return client.pause(1, function () {
     if (client.sessionId) {
       settings.sessionId = client.sessionId;
+
+      // Send this info to a parent magellan process (if present) as soon as we have it
+      // NOTE: this is only supported by magellans version 8 and higher.
+      process.send({
+        type: "selenium-session-info",
+        sessionId: client.sessionId
+      });
     }
   });
 };
@@ -17,7 +24,7 @@ module.exports = {
       //
       // 1. Keep a backup of the step.
       // 2. Replace the step with an alterate function that first quickly grabs
-      //    the selenium session id from the client object, and then calls the 
+      //    the selenium session id from the client object, and then calls the
       //    original test function.
       //
       var originalStep = steps[key];


### PR DESCRIPTION
This PR adds another IPC message for Magellan 8 which ensures the selenium session id can be associated with individual test runs (allowing for tying together stuff like saucelabs result URLs in magellan-side reporters).