### PR TITLE
Fix undefined bug in elContainsText.js

### DIFF
--- a/lib/assertions/elContainsText.js
+++ b/lib/assertions/elContainsText.js
@@ -11,7 +11,8 @@ exports.assertion = function (selector, expectedContainedText) {
   this.message = util.format('Testing if selector <%s> contains text <%s>', selector, expectedContainedText);
 
   this.pass = function () {
-    return (this.result === expectedContainedText) || (new RegExp(expectedContainedText).exec(this.result));
+    return ((this.result || expectedContainedText) !== undefined) 
+      && ((this.result === expectedContainedText) || (new RegExp(expectedContainedText).exec(this.result)));
   };
 
   this.value = function () {


### PR DESCRIPTION
Fixes #41 

Checking for undefined before "passing" the assertion. `elContainsText` used to pass even though we are passing in an `undefined` object as the expected text.

Before: 
![image](https://cloud.githubusercontent.com/assets/10262447/13100517/c7e43132-d4f2-11e5-85e0-a0e2618ed514.png)

After:
![image](https://cloud.githubusercontent.com/assets/10262447/13100508/a102b5a2-d4f2-11e5-9313-2542166a8897.png)