### PR TITLE
Ensure process.send() only used if it exists

### DIFF
--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -37,11 +37,13 @@ var emitStartedTest = function(client) {
 
     // Note: This is for Magellan versions earlier than 8 and will be ignored by
     // magellan versions 8 and above.
-    process.send({
-      type: "worker-status",
-      status: "started",
-      name: testName
-    });
+    if (process.send) {
+      process.send({
+        type: "worker-status",
+        status: "started",
+        name: testName
+      });
+    }
   }
 };
 
@@ -49,18 +51,20 @@ var emitFinishedTest = function(client, numFailures) {
 
   if (settings.isWorker === true) {
     var testName = client.currentTest.module;
-    process.send({
-      type: "worker-status",
-      status: "finished",
-      name: testName,
-      passed: (numFailures === 0) ? true : false,
-      metadata: {
-        resultURL: sauce.getTestUrl(client),
-        // Note: browserErrors has been deprecated, but we don't want to regress
-        // versions of magellan that consume this property, so we pass it along.
-        browserErrors: []
-      }
-    });
+    if (process.send) {
+      process.send({
+        type: "worker-status",
+        status: "finished",
+        name: testName,
+        passed: (numFailures === 0) ? true : false,
+        metadata: {
+          resultURL: sauce.getTestUrl(client),
+          // Note: browserErrors has been deprecated, but we don't want to regress
+          // versions of magellan that consume this property, so we pass it along.
+          browserErrors: []
+        }
+      });
+    }
   }
 
   var deferred = Q.defer();

--- a/lib/selenium-session-acquisition-wrapper.js
+++ b/lib/selenium-session-acquisition-wrapper.js
@@ -7,10 +7,12 @@ var getSessionId = function (client) {
 
       // Send this info to a parent magellan process (if present) as soon as we have it
       // NOTE: this is only supported by magellans version 8 and higher.
-      process.send({
-        type: "selenium-session-info",
-        sessionId: client.sessionId
-      });
+      if (process.send) {
+        process.send({
+          type: "selenium-session-info",
+          sessionId: client.sessionId
+        });
+      }
     }
   });
 };


### PR DESCRIPTION
This call only works when using `fork()`, and there are some cases where one might not be running as a forked process of magellan: 
  - cases where `spawn()` is used instead
  - cases where nightwatch is run from the command line directly without magellan